### PR TITLE
Merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Dviih/sync
+
+go 1.23

--- a/map.go
+++ b/map.go
@@ -1,0 +1,86 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package sync
+
+import (
+	"github.com/Dviih/sync/channel"
+	"sync"
+)
+
+type Map[K comparable, V interface{}] struct {
+	m sync.Map
+}
+
+func (maps *Map[K, V]) Load(key K) (V, bool) {
+	v, ok := maps.m.Load(key)
+	if !ok {
+		return Zero[V](), false
+	}
+
+	return v.(V), true
+}
+
+func (maps *Map[K, V]) Store(key K, value V) {
+	maps.m.Store(key, value)
+}
+
+func (maps *Map[K, V]) Delete(key K) {
+	maps.m.Delete(key)
+}
+
+func (maps *Map[K, V]) Clear() {
+	maps.m.Clear()
+}
+
+func (maps *Map[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	v, ok := maps.m.LoadOrStore(key, value)
+	if !ok {
+		return Zero[V](), false
+	}
+
+	return v.(V), true
+}
+
+func (maps *Map[K, V]) LoadAndDelete(key K) (V, bool) {
+	v, ok := maps.m.LoadAndDelete(key)
+	if !ok {
+		return Zero[V](), false
+	}
+
+	return v.(V), true
+}
+
+func (maps *Map[K, V]) Range(fn func(K, V) bool) {
+	maps.m.Range(func(k, v any) bool {
+		return fn(k.(K), v.(V))
+	})
+}
+
+func (maps *Map[K, V]) Map() map[K]V {
+	m := make(map[K]V)
+
+	maps.Range(func(k K, v V) bool {
+		m[k] = v
+		return true
+	})
+
+	return m
+}
+

--- a/map_cmp.go
+++ b/map_cmp.go
@@ -1,0 +1,39 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+//go:build !tinygo
+
+package sync
+
+func (maps *Map[K, V]) Swap(key K, value V) (V, bool) {
+	v, ok := maps.m.Swap(key, value)
+	if !ok {
+		return Zero[V](), false
+	}
+
+	return v.(V), true
+}
+
+func (maps *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
+	return maps.m.CompareAndSwap(key, old, new)
+}
+
+func (maps *Map[K, V]) CompareAndDelete(key K, value V) bool {
+	return maps.m.CompareAndDelete(key, value)
+}

--- a/map_tinygo.go
+++ b/map_tinygo.go
@@ -1,0 +1,62 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+//go:build tinygo
+
+package sync
+
+import "reflect"
+
+func (maps *Map[K, V]) Swap(key K, value V) (V, bool) {
+	p, ok := _map.Load(key)
+	if !ok {
+		p = _map.zero()
+	}
+
+	_map.Store(key, value)
+	return p, ok
+}
+
+func (maps *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
+	c, err := _map.Load(key)
+	if err != nil {
+		return false
+	}
+
+	if reflect.DeepEqual(old, c) {
+		return false
+	}
+
+	_map.Store(key, new)
+	return true
+}
+
+func (maps *Map[K, V]) CompareAndDelete(key K, value V) bool {
+	c, err := _map.Load(key)
+	if err != nil {
+		return false
+	}
+
+	if reflect.DeepEqual(value, c) {
+		return false
+	}
+
+	_map.Delete(key)
+	return true
+}

--- a/once.go
+++ b/once.go
@@ -1,0 +1,32 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package sync
+
+import (
+	"reflect"
+	"sync/atomic"
+)
+
+type Once[T interface{}] struct {
+	done   atomic.Bool
+	m      Mutex
+	result []interface{}
+}
+

--- a/pool.go
+++ b/pool.go
@@ -78,3 +78,11 @@ func (pool *Pool[T]) Put(t T) {
 	}
 }
 
+func (pool *Pool[T]) new() T {
+	if pool.New == nil {
+		return Zero[T]()
+	}
+
+	return pool.New()
+}
+

--- a/pool.go
+++ b/pool.go
@@ -27,3 +27,19 @@ type Pool[T interface{}] struct {
 	m   Mutex
 }
 
+func (pool *Pool[T]) Get() T {
+	defer pool.m.Unlock()
+	pool.m.Lock()
+
+	if len(pool.c) == 0 {
+		return pool.new()
+	}
+
+	v, ok := <-pool.c
+	if !ok {
+		return pool.new()
+	}
+
+	return v
+}
+

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,29 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package sync
+
+import "github.com/Dviih/sync/channel"
+
+type Pool[T interface{}] struct {
+	New func() T
+	c   chan T
+	m   Mutex
+}
+

--- a/slice.go
+++ b/slice.go
@@ -1,0 +1,28 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package sync
+
+import "github.com/Dviih/sync/channel"
+
+type Slice[T interface{}] struct {
+	data []T
+	m    Mutex
+}
+

--- a/slice.go
+++ b/slice.go
@@ -26,3 +26,56 @@ type Slice[T interface{}] struct {
 	m    Mutex
 }
 
+func (slice *Slice[T]) Index(i int) T {
+	defer slice.m.Unlock()
+
+	slice.m.Lock()
+	return slice.data[i]
+}
+
+func (slice *Slice[T]) Append(v ...T) {
+	defer slice.m.Unlock()
+
+	slice.m.Lock()
+	slice.data = append(slice.data, v...)
+}
+
+func (slice *Slice[T]) Delete(i int) {
+	defer slice.m.Unlock()
+
+	slice.m.Lock()
+	slice.data = append(slice.data[:i], slice.data[i+1:]...)
+}
+
+func (slice *Slice[T]) Len() int {
+	defer slice.m.Unlock()
+
+	slice.m.Lock()
+	return len(slice.data)
+}
+
+func (slice *Slice[T]) Cap() int {
+	defer slice.m.Unlock()
+
+	slice.m.Lock()
+	return cap(slice.data)
+}
+
+func (slice *Slice[T]) Range(fn func(int, T) bool) {
+	defer slice.m.Unlock()
+	slice.m.Lock()
+
+	for i, t := range slice.data {
+		if !fn(i, t) {
+			break
+		}
+	}
+}
+
+func (slice *Slice[T]) Slice() []T {
+	defer slice.m.Unlock()
+
+	slice.m.Lock()
+	return slice.data[:]
+}
+

--- a/sync.go
+++ b/sync.go
@@ -28,3 +28,6 @@ type (
 	WaitGroup = sync.WaitGroup
 )
 
+func Zero[T interface{}]() (zero T) {
+	return zero
+}

--- a/sync.go
+++ b/sync.go
@@ -1,0 +1,30 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package sync
+
+import "sync"
+
+type (
+	Locker    = sync.Locker
+	Mutex     = sync.Mutex
+	RWMutex   = sync.RWMutex
+	WaitGroup = sync.WaitGroup
+)
+

--- a/wait.go
+++ b/wait.go
@@ -1,0 +1,36 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package sync
+
+type Wait struct {
+	c chan bool
+}
+
+func (wait *Wait) Done() {
+	wait.c <- true
+}
+
+func (wait *Wait) Wait() {
+	if wait.c == nil {
+		wait.c = make(chan bool)
+	}
+
+	<-wait.c
+}


### PR DESCRIPTION
This pull request adds all stuff regarding `sync` and more!

| From | To |
| - | - |
| `OnceFunc`                 | `Once`                        |
| `OnceValue[T]`           | `Once interface{}`    |
| `OnceValues[T1, T2]` | `Once []interface{}` |
| `Cond`                          | Unchanged              |
| `Locker`                        | Unchanged              |
| `Map`                            | `Map[K, V]`               |
| `Mutex`                         | Unchanged             |
| `Pool`                            | `Pool[T]`                   |
| `RWMutex`                   | Unchanged             |
| `WaitGroup`                 | Unchanged             |
* Unchanged means they are just an alias.

---

- `Once`: done state, mutex and result saved, called by reflection.
- `Cond`: equals to `sync.Cond`.
- `Locker`: equals to `sync.Locker`.
- `Map`: underlying `sync.Map`, supports generics.
- `Mutex`: equals to `sync.Mutex`.
- `Pool`: Underlying `sync.Pool`, supporting generic.
- `RWMutex`: equals to `sync.RWMutex`.
- `WaitGroup`: equals to `sync.WaitGroup`.

Those were also introduced:
- `Slice`: underlying slice with a mutex.
- `Wait`: locks with a channel.