### PR TITLE
Implements channels for Maps, Slices and Pools.

### DIFF
--- a/map.go
+++ b/map.go
@@ -84,3 +84,17 @@ func (maps *Map[K, V]) Map() map[K]V {
 	return m
 }
 
+type MapChan[K comparable, V interface{}] struct {
+	Map[K, V]
+	channel.Manager[*channel.KV[K, V]]
+}
+
+func (mc *MapChan[K, V]) Sender() chan<- *channel.KV[K, V] {
+	if mc.Manager.Handler == nil {
+		mc.Manager.Handler = func(kv *channel.KV[K, V]) {
+			mc.Map.Store(kv.Key, kv.Value)
+		}
+	}
+
+	return mc.Manager.Sender()
+}

--- a/pool.go
+++ b/pool.go
@@ -50,3 +50,17 @@ func (pool *Pool[T]) new() T {
 	return pool.New()
 }
 
+type PoolChan[T interface{}] struct {
+	Pool[T]
+	channel.Manager[T]
+}
+
+func (pc *PoolChan[T]) Sender() chan<- T {
+	if pc.Manager.Handler == nil {
+		pc.Manager.Handler = func(t T) {
+			pc.Pool.Put(t)
+		}
+	}
+
+	return pc.Manager.Sender()
+}

--- a/slice.go
+++ b/slice.go
@@ -79,3 +79,17 @@ func (slice *Slice[T]) Slice() []T {
 	return slice.data[:]
 }
 
+type SliceChan[T interface{}] struct {
+	Slice[T]
+	channel.Manager[T]
+}
+
+func (sc *SliceChan[T]) Sender() chan<- T {
+	if sc.Manager.Handler == nil {
+		sc.Manager.Handler = func(t T) {
+			sc.Append(t)
+		}
+	}
+
+	return sc.Manager.Sender()
+}


### PR DESCRIPTION
This pull request adds channels support for the types above.
All must include custom handler as they are different when inserting data.
`Channel.Manager[T]` is the base here.
Map uses `Channel.KV` as it's required to have both key and value and not only one as it would be pointless as described in #3.