### PR TITLE
Channels and Manager.

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -1,0 +1,35 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package channel
+
+type Channel[T interface{}] interface {
+	Sender() chan<- T
+	Receiver() <-chan T
+}
+
+type Logic[T interface{}] interface {
+	Send(T) bool
+	Receive() (T, bool)
+}
+
+type KV[K comparable, V interface{}] struct {
+	Key   K
+	Value V
+}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -21,7 +21,7 @@ package channel
 
 type Channel[T interface{}] interface {
 	Sender() chan<- T
-	Receiver() <-chan T
+	Receiver(...int) <-chan T
 }
 
 type Logic[T interface{}] interface {

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -33,3 +33,21 @@ type Manager[T interface{}] struct {
 	Dead    chan uintptr
 }
 
+func (manager *Manager[T]) Sender() chan<- T {
+	c := make(chan T)
+
+	go func() {
+		for {
+			select {
+			case t, ok := <-c:
+				if !ok {
+					return
+				}
+
+				go manager.handle(t)
+			}
+		}
+	}()
+
+	return c
+}

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -51,8 +51,17 @@ func (manager *Manager[T]) Sender() chan<- T {
 	return c
 }
 
-func (manager *Manager[T]) Receiver() <-chan T {
-	c := make(chan T)
+func (manager *Manager[T]) Receiver(v ...int) <-chan T {
+	var c chan T
+
+	switch len(v) {
+	case 0:
+		c = make(chan T)
+	case 1:
+		c = make(chan T, v[0])
+	default:
+		panic("invalid receiver length")
+	}
 
 	manager.receivers.Store(c, true)
 	return c

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -24,3 +24,12 @@ import (
 	"sync"
 )
 
+type Manager[T interface{}] struct {
+	m         sync.Mutex
+	receivers []chan T
+	dead      map[chan T]bool
+
+	Handler func(T)
+	Dead    chan uintptr
+}
+

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -51,3 +51,14 @@ func (manager *Manager[T]) Sender() chan<- T {
 
 	return c
 }
+
+func (manager *Manager[T]) Receiver() <-chan T {
+	defer manager.m.Unlock()
+
+	c := make(chan T)
+	manager.m.Lock()
+
+	manager.receivers = append(manager.receivers, c)
+	return c
+}
+

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -1,0 +1,26 @@
+/*
+ *     Drop-in replacement for Go's sync featuring generics and channels.
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package channel
+
+import (
+	"reflect"
+	"sync"
+)
+

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -25,9 +25,8 @@ import (
 )
 
 type Manager[T interface{}] struct {
-	m         sync.Mutex
-	receivers []chan T
-	dead      map[chan T]bool
+	receivers sync.Map
+	dead      sync.Map
 
 	Handler func(T)
 	Dead    chan uintptr
@@ -53,12 +52,9 @@ func (manager *Manager[T]) Sender() chan<- T {
 }
 
 func (manager *Manager[T]) Receiver() <-chan T {
-	defer manager.m.Unlock()
-
 	c := make(chan T)
-	manager.m.Lock()
 
-	manager.receivers = append(manager.receivers, c)
+	manager.receivers.Store(c, true)
 	return c
 }
 

--- a/map.go
+++ b/map.go
@@ -84,3 +84,17 @@ func (maps *Map[K, V]) Map() map[K]V {
 	return m
 }
 
+type MapChan[K comparable, V interface{}] struct {
+	Map[K, V]
+	channel.Manager[*channel.KV[K, V]]
+}
+
+func (mc *MapChan[K, V]) Sender() chan<- *channel.KV[K, V] {
+	if mc.Manager.Handler == nil {
+		mc.Manager.Handler = func(kv *channel.KV[K, V]) {
+			mc.Map.Store(kv.Key, kv.Value)
+		}
+	}
+
+	return mc.Manager.Sender()
+}

--- a/pool.go
+++ b/pool.go
@@ -50,3 +50,17 @@ func (pool *Pool[T]) new() T {
 	return pool.New()
 }
 
+type PoolChan[T interface{}] struct {
+	Pool[T]
+	channel.Manager[T]
+}
+
+func (pc *PoolChan[T]) Sender() chan<- T {
+	if pc.Manager.Handler == nil {
+		pc.Manager.Handler = func(t T) {
+			pc.Pool.Put(t)
+		}
+	}
+
+	return pc.Manager.Sender()
+}

--- a/slice.go
+++ b/slice.go
@@ -79,3 +79,17 @@ func (slice *Slice[T]) Slice() []T {
 	return slice.data[:]
 }
 
+type SliceChan[T interface{}] struct {
+	Slice[T]
+	channel.Manager[T]
+}
+
+func (sc *SliceChan[T]) Sender() chan<- T {
+	if sc.Manager.Handler == nil {
+		sc.Manager.Handler = func(t T) {
+			sc.Append(t)
+		}
+	}
+
+	return sc.Manager.Sender()
+}


### PR DESCRIPTION
This pull request follows #3 guide.

The Manager was an open question so there is a breakdown of how it is implemented. The main concept of a manager is unifying all receivers that senders can call at anytime safely.
In case of dead receivers manager is able to clean it up, if a channel fails once it will be put into a `dead` list and only after failing inside this list it will be removed. If the same receiver comes back alive it will be removed from dead list but must not fail twice, the `Dead` property is used to notify dead channels and so the application can clean it up.
Receivers can be initialized with a capacity.

The Handler property inside Manager is used to insert data into other data types.

---

A breakdown of Channel interface:
- Sender:  `Sender() chan<- T` creates a sender to send data to a list of receivers.
- Receiver: `Receive(...capacity) <-chan` creates a receiver to receive data from senders.

---

A breakdown of Logic interface:
###### This interface was made to be the reflection of `Channel` interface above, not used.
- Send: `Send(T)` sends data to a list of receivers.
- Receive: `Receive() (T, bool)` receives data from senders.

---

A breakdown of KV (Key-Value, used for maps):
- Key: `K` field including key value, must be comparable.
- Value: `V` field including value value.

---

Manager breakdown:

- receivers: `sync.Map` a property to store all alive receivers, it is a map with value of true always, only key is relevant.
- dead: `sync.Map` a property to store all dead receivers, it is a map with value of true always, only key is relevant.
- Handler: `func()` a custom function to be called before `handle(T)`, used to insert into other data types.
- Dead: `chan uintptr` a channel used to notify newly dead channels.

Manager implements Channel interface so does its methods.
The `handle(T)` is the heart of Manager it first calls Handler and sends new data to each receiver in a goroutine. The send operation is non blocking so if it fails it will be put in dead map and pruned upon next fail if no successful send happened in between. In case of any dead channel removed `Dead` will be notified.