### PR TITLE
Patches

### DIFF
--- a/channel/manager.go
+++ b/channel/manager.go
@@ -74,7 +74,7 @@ func (manager *Manager[T]) handle(t T) {
 
 	var wg sync.WaitGroup
 
-	manager.receivers.Range(func(key, value any) bool {
+	manager.receivers.Range(func(key, _ interface{}) bool {
 		wg.Add(1)
 
 		go func(receiver chan T) {

--- a/map.go
+++ b/map.go
@@ -68,7 +68,7 @@ func (maps *Map[K, V]) LoadAndDelete(key K) (V, bool) {
 }
 
 func (maps *Map[K, V]) Range(fn func(K, V) bool) {
-	maps.m.Range(func(k, v any) bool {
+	maps.m.Range(func(k, v interface{}) bool {
 		return fn(k.(K), v.(V))
 	})
 }

--- a/slice.go
+++ b/slice.go
@@ -76,7 +76,11 @@ func (slice *Slice[T]) Slice() []T {
 	defer slice.m.Unlock()
 
 	slice.m.Lock()
-	return slice.data[:]
+
+	data := make([]T, len(slice.data))
+	copy(data, slice.data)
+
+	return data
 }
 
 type SliceChan[T interface{}] struct {


### PR DESCRIPTION
This is a very small patch collection before the full release of `sync`!

One thing about slices was by design `[:]` does shallow copy but not so much, so after a `slices.Sort` the values of the slice was also changed and not from the copy.
Before:
```go
slice := &sync.Slice[string]{}

slice.Append("World", "Hello")
fmt.Println(slice.Slice()) // [World Hello]

sliced := slice.Slice()
slices.Sort(sliced)

fmt.Println(sliced) // [Hello World]
fmt.Println(slice.Slice()) // [Hello World]
```
After:
```go
...

sliced := slice.Slice()
slices.Sort(sliced)

fmt.Println(sliced) // [Hello World]
fmt.Println(slice.Slice()) // [World Hello]
```

And a couple naming for manager receivers loop inside handler, for value being _ and type from any to `interface{}` and the same for Map inside Range.