### PR TITLE
Extended Once methods.

### DIFF
--- a/once.go
+++ b/once.go
@@ -32,6 +32,10 @@ type Once[T interface{}] struct {
 }
 
 func (once *Once[T]) Do(fn T) interface{} {
+	if once.r != nil {
+		panic(once.r)
+	}
+
 	if once.done.Load() {
 		switch len(once.result) {
 		case 0:

--- a/once.go
+++ b/once.go
@@ -76,3 +76,11 @@ func OnceFunc(fn func()) func() {
 	}
 }
 
+func OnceValue[T interface{}](fn func() T) func() T {
+	once := &Once[func() T]{}
+
+	return func() T {
+		return once.Do(fn).(T)
+	}
+}
+

--- a/once.go
+++ b/once.go
@@ -67,3 +67,12 @@ func (once *Once[T]) Do(fn T) interface{} {
 		return once.result[:]
 	}
 }
+
+func OnceFunc(fn func()) func() {
+	once := &Once[func()]{}
+
+	return func() {
+		once.Do(fn)
+	}
+}
+

--- a/once.go
+++ b/once.go
@@ -28,6 +28,7 @@ type Once[T interface{}] struct {
 	done   atomic.Bool
 	m      Mutex
 	result []interface{}
+	r      interface{}
 }
 
 func (once *Once[T]) Do(fn T) interface{} {
@@ -52,10 +53,10 @@ func (once *Once[T]) Do(fn T) interface{} {
 	}
 
 	defer func() {
-		r := recover()
+		once.r = recover()
 
 		if !once.done.Load() {
-			panic(r)
+			panic(once.r)
 		}
 	}()
 

--- a/once.go
+++ b/once.go
@@ -51,6 +51,14 @@ func (once *Once[T]) Do(fn T) interface{} {
 		panic("once: Do func must not have input arguments")
 	}
 
+	defer func() {
+		r := recover()
+
+		if !once.done.Load() {
+			panic(r)
+		}
+	}()
+
 	out := v.Call(nil)
 	for i := 0; i < len(out); i++ {
 		once.result = append(once.result, out[i].Interface())

--- a/once.go
+++ b/once.go
@@ -84,3 +84,12 @@ func OnceValue[T interface{}](fn func() T) func() T {
 	}
 }
 
+func OnceValues[T1, T2 interface{}](fn func() (T1, T2)) func() (T1, T2) {
+	once := &Once[func() (T1, T2)]{}
+
+	return func() (T1, T2) {
+		i := once.Do(fn)
+
+		return i.([]interface{})[0].(T1), i.([]interface{})[1].(T2)
+	}
+}


### PR DESCRIPTION
Let's extend and support all of Once here. The parity with `OnceFunc`, `OnceValue` and `OnceValues` was added in this update and they are backed by own `Once` not from `sync` package.
A panic handler was also added during the call to `Do`, if one recover happens it is set to `r` and every call after it will panic.