### PR TITLE
Wait (2)

### DIFF
--- a/wait.go
+++ b/wait.go
@@ -35,6 +35,7 @@ func (wait *Wait) C() <-chan bool {
 }
 
 func (wait *Wait) Done() {
+	wait.lazy()
 	wait.c <- true
 }
 

--- a/wait.go
+++ b/wait.go
@@ -40,9 +40,5 @@ func (wait *Wait) Done() {
 }
 
 func (wait *Wait) Wait() {
-	if wait.c == nil {
-		wait.c = make(chan bool)
-	}
-
-	<-wait.c
+	<-wait.C()
 }

--- a/wait.go
+++ b/wait.go
@@ -23,6 +23,12 @@ type Wait struct {
 	c chan bool
 }
 
+func (wait *Wait) lazy() {
+	if wait.c == nil {
+		wait.c = make(chan bool)
+	}
+}
+
 func (wait *Wait) Done() {
 	wait.c <- true
 }

--- a/wait.go
+++ b/wait.go
@@ -29,6 +29,11 @@ func (wait *Wait) lazy() {
 	}
 }
 
+func (wait *Wait) C() <-chan bool {
+	wait.lazy()
+	return wait.c
+}
+
 func (wait *Wait) Done() {
 	wait.c <- true
 }


### PR DESCRIPTION
Wait can now support `select` method and is even safer as it includes lazy init in every method (only a couple but still)
Wait:
Done() sends true
C() returns a channel
Wait() locks until receives something
is the current architecture.